### PR TITLE
MXY 2022.3.8: FIX issue of a single-week-class

### DIFF
--- a/api/tools/njuyjsxk.js
+++ b/api/tools/njuyjsxk.js
@@ -46,6 +46,9 @@ function scheduleHtmlParser() {
       } else if (strs[4] == '双') {
         for (let z = parseInt(strs[1]); z <= parseInt(strs[3]); z += 2)
           weeks.push(z);
+      } else if (typeof(strs[2]) == 'undefined'){
+          // Just a single weak ...
+          weeks.push(parseInt(strs[1]));
       } else {
         for (let z = parseInt(strs[1]); z <= parseInt(strs[3]); z++)
           weeks.push(z);


### PR DESCRIPTION
修复研究生导入API中，（形式上）只开一周的课程不能正确解析而导致周次列表为空的问题。
例如  17周 星期二[3-4节]

P.S 看起来，如果上课周次为空，APP里面的逻辑也会出问题。