### PR TITLE
fix：NWAFU课程表导入失败

### DIFF
--- a/api/schoolList.json
+++ b/api/schoolList.json
@@ -243,7 +243,7 @@
       "pinyin": "xibeinonglinkejidaxuebksjiaowu",
       "description": "西北怎么不算一种南哪儿呢",
       "page_title": "统一身份认证",
-      "initialUrl": "https://authserver.nwafu.edu.cn/authserver/login?service=https%3A%2F%2Fnewehall.nwafu.edu.cn%2Fjwapp%2Fsys%2Fwdkbby%2F*default%2Findex.do",
+      "initialUrl": "https://authserver.nwafu.edu.cn/authserver/login?service=https%3A%2F%2Fnewehall.nwafu.edu.cn%2Fjwapp%2Fsys%2Fwdkbby%2F*default%2Findex.do%23%2Fxskcb",
       "redirectUrl": "",
       "targetUrl": "https://newehall.nwafu.edu.cn/jwapp/sys/wdkbby/*default/index.do#/xskcb",
       "preExtractJS": "",


### PR DESCRIPTION
尝试修复NWAFU在iOS和HarmonyOS系统中课程表导入失败的问题